### PR TITLE
fixed the auto-completed address suffix

### DIFF
--- a/server/controllers/properties.js
+++ b/server/controllers/properties.js
@@ -19,7 +19,7 @@ middlewares.getPropertiesForSale = async (req, res, next) => {
   console.log(req.query);
   const url = new URL('https://zillow-com1.p.rapidapi.com/propertyExtendedSearch');
   const params = {
-    location: req.query.location,
+    location: req.query.location.replace(/, United States$/, ''),
     status_type: 'ForSale',
   };
   if (req.query.home_type !== '')  params.home_type = req.query.home_type;

--- a/server/routes/properties.js
+++ b/server/routes/properties.js
@@ -4,7 +4,7 @@ const router = express.Router();
 const middlewares = require('../controllers/properties');
 
 // handler for submitted form with a single address or area search
-router.post('/',
+router.all('/',
   middlewares.getPropertiesForSale,
   (req, res, next) => {
     if ('zpid' in res.locals) {


### PR DESCRIPTION
When a user searches using the text field on the map, the autocompletion will add the country suffix (e.g., 'United States') to the query, which cannot be handled by the RapidAPI. This patch fixes this issue by removing the country suffix.